### PR TITLE
Fixing bug in VM/Amazon

### DIFF
--- a/ApplyTransformations/Task/ApplyTransforms.ps1
+++ b/ApplyTransformations/Task/ApplyTransforms.ps1
@@ -1,7 +1,8 @@
 param(
     [string]$buildConfiguration,
     [string]$extension,
-    [string]$dllFolder
+    [string]$dllFolder,
+    [string]$MSBuildExePath
 )
 
 $dllFullPath = Join-Path $dllFolder "Microsoft.Web.XmlTransform.dll"
@@ -57,7 +58,7 @@ if($files)
             $BuildXml | Out-File $BuildXmlWork
 
             # call msbuild
-            & MSBuild.exe $BuildXmlWork
+            & $MSBuildExePath $BuildXmlWork
 
             # copy the output to the desired location
             Copy-Item $OutputWork $org

--- a/ApplyTransformations/Task/task.json
+++ b/ApplyTransformations/Task/task.json
@@ -50,6 +50,15 @@
             "required": true,
             "groupName": "advanced",
             "helpMarkDown": "The folder which contains the Microsoft.Web.XmlTransform.dll."
+        },
+        {
+            "name": "MSBuildExePath",
+            "type": "string",
+            "label": "MSBuild.exe path",
+            "defaultValue": "C:\\Program Files (x86)\\MSBuild\\14.0\\Bin\\MSBuild.exe",
+            "required": true,
+            "groupName": "advanced",
+            "helpMarkDown": "Path to MSBuild.exe file."
         }
     ],
     "execution": {


### PR DESCRIPTION
I have a Build-Agent running on Amazon, and use an **ApplyTransformations extension**, line that calls the MSBuild.exe executable failed.

Line of error with debug data:
_System.Management.Automation.CommandNotFoundException: The term 'MSBuild.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path has been included, make sure the path is correct and try again._

```
PowerShell version = 4.0
ApplyTransformations version = 1.1.0
```